### PR TITLE
Revert "Disable pose prediction"

### DIFF
--- a/app/src/main/src/main.cpp
+++ b/app/src/main/src/main.cpp
@@ -1248,7 +1248,7 @@ cxrDeviceDesc CloudXRClientOVR::GetDeviceDesc(float fovX, float fovY)
     desc.receiveAudio = GOptions.mReceiveAudio;
     desc.sendAudio = GOptions.mSendAudio;
     desc.posePollFreq = 0;
-    desc.disablePosePrediction = true;
+    desc.disablePosePrediction = false;
     desc.angularVelocityInDeviceSpace = false;
     desc.foveatedScaleFactor = (GOptions.mFoveation < 100) ? GOptions.mFoveation : 0;
     // if we have touch controller use Oculus type, else use Vive as more close to 3dof remotes


### PR DESCRIPTION
### Notes

Not enough testing was done for disabling prediction.
As it turns out, prediction is what makes CXR have amazing latency.
Prediction time can be decreased, but fully disabling breaks the usability.